### PR TITLE
Fix time-complexity issue in mock lpush/rpush

### DIFF
--- a/src/predis/mock.clj
+++ b/src/predis/mock.clj
@@ -328,7 +328,7 @@
 
   (core/lpush [this k v-or-vs]
     (let [vs' (util/vec-wrap v-or-vs)
-          do-push (fn [old-vs new-v] (cons new-v (or old-vs [])))]
+          do-push (fn [old-vs new-v] (cons new-v (or (seq old-vs) '())))]
       (doseq [v vs']
         (swap! store update-in [k] do-push (str v)))
       (core/llen this k)))
@@ -393,7 +393,7 @@
 
   (core/rpush [this k v-or-vs]
     (let [vs' (util/vec-wrap v-or-vs)
-          do-push (fn [old-vs] (concat (or old-vs []) (map str vs')))]
+          do-push (fn [old-vs] (apply conj (vec old-vs) (map str vs')))]
       (swap! store update-in [k] do-push)
       (core/llen this k)))
 


### PR DESCRIPTION
Prior to this commit, the mock implementations of lpush and rpush were
O(N) rather than O(1) like they are in Redis, due to using underlying
data structures that were not tuned for prepending/appending.
In Clojure:
- list:   (): O(1) prepend, O(N) append
- vector: []: O(N) prepend, O(1) append

Although in general time complexity parity isn't a goal in the mock,
these particular operations need approx. O(1) insert for some systems
tests/benchmarks we have.

This commit adds a compromise fix: assuming you are always prepending
or always appending, the mock will set up and use the data structures
appropriately in an O(1) manner.  If you ever switch from inserting
from one end to the other on the same key, the mock will incur an O(N)
conversion cost, and then go back to O(1) on subsequent calls to the
same operation on the same key.

This should provide the expected performance most of the time,
assuming callers are not usually switching their access patterns back
and forth, which would seem less common.  The external return value
behavior should be unchanged, as the value comparisons should be
always being done in the common denominator of seqs.
