### PR TITLE
Skip making new vector when mock coll already vec

### DIFF
--- a/src/predis/mock.clj
+++ b/src/predis/mock.clj
@@ -393,7 +393,7 @@
 
   (core/rpush [this k v-or-vs]
     (let [vs' (util/vec-wrap v-or-vs)
-          do-push (fn [old-vs] (apply conj (vec old-vs) (map str vs')))]
+          do-push (fn [old-vs] (apply conj (util/to-vec old-vs) (map str vs')))]
       (swap! store update-in [k] do-push)
       (core/llen this k)))
 

--- a/src/predis/util.clj
+++ b/src/predis/util.clj
@@ -97,3 +97,10 @@
                         [(conj xs' el) nremoved]))
         init [[] 0]]
     (reduce counting-remove init xs)))
+
+(defn to-vec [coll]
+  "Return a vector of the given collection,
+  NOT creating a new one, unlike `vec`."
+  (if (vector? coll)
+    coll
+    (vec coll)))


### PR DESCRIPTION
9edd10d056b5b25140eaf615f6d0351dd73384fc itself had a perf bug since
`vec` isn't fully _performance_ idempotent.  If given a vector, `vec`
will return a new vector, which isn't the behavior we want, we just
want to return the existing vector.  This commit fixes the issue
which actually delivers the constant-time performance on `rpush`.
