### PR TITLE
Fix behavior of LTRIM

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.andrewberls/predis "0.1.6"
+(defproject com.andrewberls/predis "0.1.7"
   :description "An in-memory Redis mock for Clojure"
   :url "https://github.com/andrewberls/predis"
   :license {:name "MIT License"

--- a/test/predis/lists_test.clj
+++ b/test/predis/lists_test.clj
@@ -116,9 +116,11 @@
 (defspec test-ltrim
   test-utils/nruns
   (let [mock-client (mock/->redis)]
-    (prop/for-all [k (gen/not-empty (gen/vector gen/int))
-                   start gen/int
-                   stop gen/int]
+    (prop/for-all [k gen/string-alphanumeric
+                   vs (gen/not-empty (gen/vector gen/int))
+                   start gen/pos-int
+                   stop gen/pos-int]
+      (test-utils/assert-rpush mock-client carmine-client k vs)
       (is (= (r/ltrim mock-client k start stop)
              (r/ltrim carmine-client k start stop)))
       (test-utils/dbs-equal mock-client carmine-client))))


### PR DESCRIPTION
http://redis.io/commands/ltrim
- "Out of range indexes will not produce an error: if start is larger
  than the end of the list, or start > end, the result will be an empty
  list (which causes key to be removed)"
- Fix some negative index behavior
